### PR TITLE
cli: version flag (Fixes #42)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,7 @@ builds:
     binary: pgrwl
     ldflags:
       - -s -w
+      - -X 'github.com/hashmap-kz/pgrwl/version.Version={{.Version}}'
     env:
       - CGO_ENABLED=0
     goos:

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashmap-kz/pgrwl/config"
 	"github.com/hashmap-kz/pgrwl/internal/core/logger"
 	"github.com/hashmap-kz/pgrwl/internal/opt/optutils"
+	"github.com/hashmap-kz/pgrwl/internal/version"
 	"github.com/urfave/cli/v3"
 )
 
@@ -108,6 +109,15 @@ func App() *cli.Command {
 							Addr: c.String("serve-addr"),
 						},
 					)
+				},
+			},
+			{
+				Name:    "version",
+				Aliases: []string{"v"},
+				Usage:   "Show version information",
+				Action: func(_ context.Context, c *cli.Command) error {
+					fmt.Println(version.Version)
+					return nil
 				},
 			},
 		},

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,4 @@
+package version
+
+// Version holds the current stable version
+var Version = "dev"


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to pgrwl! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This change introduces a `version` CLI flag to the `pgrwl` tool.  
The version is dynamically injected at build time using `-ldflags`.  
This improves usability by allowing users to quickly identify which version of the binary they are running.

Additionally:
- The `.goreleaser.yml` file has been updated to properly inject version information.
- The default version value is set to `"dev"` if not set during build.


#### Was the change discussed in an issue or in the forum before?

Yes, this addresses [hashmap-kz/pgrwl#42](https://github.com/hashmap-kz/pgrwl/issues/42).

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/hashmap-kz/pgrwl/blob/master/CONTRIBUTING.md).
- [ ] I have added unit-tests for all changes in this PR if appropriate.
- [ ] I have added integration-tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] I'm done, this Pull Request is ready for review :-)
