### PR TITLE
fix(app): improve PostgreSQL env vars validation

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -210,14 +210,24 @@ func loadConfig(c *cli.Command, mode string) *config.Config {
 }
 
 func checkPgEnvsAreSet() {
-	// TODO: PGPASSFILE, etc...
 	var emptyEnvs []string
-	for _, name := range []string{"PGHOST", "PGPORT", "PGUSER", "PGPASSWORD"} {
+	for _, name := range []string{"PGHOST", "PGPORT", "PGUSER"} { //you can add additional fields if needed
 		if os.Getenv(name) == "" {
 			emptyEnvs = append(emptyEnvs, name)
 		}
 	}
+
+	if os.Getenv("PGPASSWORD") == "" && os.Getenv("PGPASSFILE") == "" {
+		emptyEnvs = append(emptyEnvs, "PGPASSWORD or PGPASSFILE")
+	}
+
 	if len(emptyEnvs) > 0 {
 		log.Fatalf("[FATAL] receive: required env vars are empty: [%s]", strings.Join(emptyEnvs, " "))
+	}
+
+	if os.Getenv("PGPASSFILE") != "" {
+		if _, err := os.Stat(os.Getenv("PGPASSFILE")); os.IsNotExist(err) {
+			log.Fatalf("[FATAL] PGPASSFILE does not exist: %s", os.Getenv("PGPASSFILE"))
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to pgrwl! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This change improves the PostgreSQL environment variables validation in the `checkPgEnvsAreSet()` function. The enhancements include:

- Added support for `PGPASSFILE` authentication method as an alternative to `PGPASSWORD`
- Implemented proper file existence check for `PGPASSFILE` when specified
- Maintained backward compatibility with existing `PGPASSWORD` usage

#### Was the change discussed in an issue or in the forum before?

No, this improvement addresses an existing TODO comment in the code that indicated the need to support additional PostgreSQL environment variables like `PGPASSFILE`.

#### Checklist

- [x ] I have read the [contribution guidelines](https://github.com/hashmap-kz/pgrwl/blob/master/CONTRIBUTING.md).
- [ ] I have added unit-tests for all changes in this PR if appropriate.
- [ ] I have added integration-tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x ] I'm done, this Pull Request is ready for review :-)
