### PR TITLE
feat(config): warn on unknown yaml keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -5,13 +5,16 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/sethvargo/go-envconfig"
+	yamlv3 "gopkg.in/yaml.v3"
 
 	"sigs.k8s.io/yaml"
 )
@@ -372,7 +375,9 @@ func mustLoadCfg(path string) (*Config, error) {
 			return nil, err
 		}
 	case ".yml", ".yaml":
-		if err := yaml.Unmarshal(expand(configData), &cfg); err != nil {
+		expanded := expand(configData)
+		warnUnknownYAMLKeys(expanded)
+		if err := yaml.Unmarshal(expanded, &cfg); err != nil {
 			return nil, err
 		}
 	default:
@@ -380,6 +385,75 @@ func mustLoadCfg(path string) (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+func warnUnknownYAMLKeys(data []byte) {
+	for _, key := range unknownYAMLKeys(data, reflect.TypeOf(Config{})) {
+		slog.Warn("unknown config key", slog.String("key", key))
+	}
+}
+
+func unknownYAMLKeys(data []byte, typ reflect.Type) []string {
+	var root yamlv3.Node
+	if err := yamlv3.Unmarshal(data, &root); err != nil || len(root.Content) == 0 {
+		return nil
+	}
+
+	return collectUnknownYAMLKeys(root.Content[0], typ, "")
+}
+
+func collectUnknownYAMLKeys(node *yamlv3.Node, typ reflect.Type, prefix string) []string {
+	typ = indirectType(typ)
+	if node == nil || node.Kind != yamlv3.MappingNode || typ.Kind() != reflect.Struct {
+		return nil
+	}
+
+	fields := jsonFieldsByName(typ)
+	var unknown []string
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+		key := keyNode.Value
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+
+		field, ok := fields[key]
+		if !ok {
+			unknown = append(unknown, path)
+			continue
+		}
+
+		unknown = append(unknown, collectUnknownYAMLKeys(valueNode, field.Type, path)...)
+	}
+	return unknown
+}
+
+func jsonFieldsByName(typ reflect.Type) map[string]reflect.StructField {
+	fields := make(map[string]reflect.StructField)
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+		name := strings.Split(field.Tag.Get("json"), ",")[0]
+		if name == "" {
+			name = field.Name
+		}
+		if name == "-" {
+			continue
+		}
+		fields[name] = field
+	}
+	return fields
+}
+
+func indirectType(typ reflect.Type) reflect.Type {
+	for typ.Kind() == reflect.Pointer {
+		typ = typ.Elem()
+	}
+	return typ
 }
 
 // validate checks that all required fields in the config are set appropriately.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -192,6 +195,47 @@ func TestFromEnvsInvalidValuesReturnErrors(t *testing.T) {
 	assert.Nil(t, cfg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "receiver.uploader.sync_interval cannot parse")
+}
+
+func TestUnknownYAMLKeysReportsNestedPaths(t *testing.T) {
+	keys := unknownYAMLKeys([]byte(`main:
+  listen_port: 9090
+recevier:
+  slot: typo
+storage:
+  name: s3
+  s3:
+    bukcet: typo-bucket
+`), reflect.TypeOf(Config{}))
+
+	assert.ElementsMatch(t, []string{"recevier", "storage.s3.bukcet"}, keys)
+}
+
+func TestMustLoadCfgWarnsOnUnknownYAMLKeys(t *testing.T) {
+	var logs bytes.Buffer
+	originalLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() {
+		slog.SetDefault(originalLogger)
+	})
+
+	path := writeConfigForTest(t, `main:
+  listen_port: 9090
+  directory: /tmp/pgrwl
+recevier:
+  slot: receive_slot
+receiver:
+  slot: receive_slot
+backup:
+  cron: "* * * * *"
+storage:
+  name: local
+`)
+
+	_, err := mustLoadCfg(path)
+	assert.NoError(t, err)
+	assert.Contains(t, logs.String(), "unknown config key")
+	assert.Contains(t, logs.String(), "recevier")
 }
 
 func TestValidate_Config(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/urfave/cli/v3 v3.8.0
 	golang.org/x/crypto v0.50.0
 	golang.org/x/time v0.15.0
+	gopkg.in/yaml.v3 v3.0.1
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -54,5 +55,4 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
#### What is the purpose of this pull request?

Warns when YAML config files contain keys that do not map to the `Config` schema, including nested paths like `storage.s3.bukcet`. This keeps the existing load behavior intact while surfacing typos such as `recevier:` that would otherwise be ignored.

Closes #275

#### Was the change discussed in an issue or in the discussions before?

Issue #275

#### Checklist

- [x] I have read the CONTRIBUTING.md document.
- [x] I have added or updated unit tests for this change.
- [ ] I have added or updated integration tests for this change. (not applicable)
- [ ] I have updated documentation for this change. (not applicable)
- [x] This pull request is ready for review.

#### Tests

- `~/.local/go/bin/go test ./config`
- `~/.local/go/bin/go test ./...`